### PR TITLE
 Fix "Open in Colab" Button for Advanced Azure AI Evaluation Notebook

### DIFF
--- a/Class-Labs/Module-4(Evaluations & Responsible AI)/Lab-2(Azure-_AI_evaluators)/Readme.md
+++ b/Class-Labs/Module-4(Evaluations & Responsible AI)/Lab-2(Azure-_AI_evaluators)/Readme.md
@@ -1,6 +1,6 @@
-# Lab 3: Advanced Azure AI Evaluation - Introduction
+# Lab 2: Advanced Azure AI Evaluation - Introduction
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](<https://colab.research.google.com/github/sachin0034/hands_on_AI_introduction_to_AI_evaluations-4038348/blob/main/Lab-3%28Building_AI_evaluators%29/Advanced_Azure_AI_Evaluation.ipynb>)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/initmahesh/MLAI-community-labs/blob/main/Class-Labs/Module-4(Evaluations%20%26%20Responsible%20AI)/Lab-2(Azure-_AI_evaluators)/Advanced_Azure_AI_Evaluation.ipynb)
 
 
 


### PR DESCRIPTION
Fixed the broken "Open in Colab" link for the `Advanced_Azure_AI_Evaluation.ipynb` notebook in **Lab-2 (Azure AI Evaluators)**.