### PR TITLE
Fixed expression of the user_query variable inside AI agent

### DIFF
--- a/Cohort-Labs/cohort-10/week-1-intro-agents/1.2 - claude-prototype/readme.md
+++ b/Cohort-Labs/cohort-10/week-1-intro-agents/1.2 - claude-prototype/readme.md
@@ -343,7 +343,10 @@ Find the **user message** field. It's currently set to read from the old n8n cha
 Replace whatever is in that field with this:
 
 ```
-{{ $json.body.message }}
+
+user_query:{{ $('Webhook').item.json.body.
+message }}
+file_context:{{ $json.text }}
 ```
 
 This tells the agent: "don't look for a hardcoded question — read whatever message the user just sent from the web app." The curly braces are n8n's way of saying "pull this value in live from what just arrived."


### PR DESCRIPTION
The expression for the user_query variable was incorrect and I got an error when I followed the tutorial. I fixed it and I have shared the actual expression of the user_query variable.
Message" src="https://github.com/user-attachments/assets/66042779-0334-4d95-9e51-0e4c95b3bad7" />
